### PR TITLE
Integrate security config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Este projeto é uma aplicação Flask para automação de documentos Google Docs
 - **Proxy reverso**: Nginx com headers de segurança
 - **Backup Automático**: Backup diário local e sincronização com Google Drive
 - **Segurança**: Rate limiting, CSRF protection, CORS, Headers de segurança
+  - Configurações extras carregadas de `security_config.py` em `application.py`
 - **Monitoramento**: Grafana Loki (logs centralizados)
 - **Qualidade de Código**: ESLint + Prettier para JavaScript/TypeScript
 - **Publicação externa**: Cloudflare Tunnel (cloudflared)

--- a/application.py
+++ b/application.py
@@ -31,6 +31,7 @@ from werkzeug.security import check_password_hash, generate_password_hash
 
 from config import CONFIG
 from document_generator import buscar_ou_criar_pasta_cliente, gerar_documento_cliente
+from security_config import get_security_config
 from security_middleware import SecurityMiddleware, require_api_key
 
 # Inicializar extensões
@@ -67,6 +68,9 @@ app.config.update(
     WTF_CSRF_ENABLED=True,
     WTF_CSRF_TIME_LIMIT=3600,  # 1 hora
 )
+
+# Carregar configurações adicionais de segurança
+app.config.update(get_security_config())
 
 # Inicializar extensões
 csrf.init_app(app)


### PR DESCRIPTION
## Summary
- load security_config in `application.py`
- mention that security_config options are now loaded in the README

## Testing
- `black application.py`
- `isort application.py`
- `mypy application.py` *(fails: Error importing plugin 'pydantic.mypy')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599aa671b48322ac3531fa4f7fbf07