### PR TITLE
Fix imports, cleanup config, and add requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ O script `install.sh` automatiza a configuração do ambiente e instalação da 
 
    - Instalar dependências do sistema (python3-venv, nginx, rclone, nodejs, etc.)
    - Criar e configurar ambiente virtual Python (`venv`)
-   - Instalar dependências Python de segurança (do arquivo `requirements-secure.txt`)
+   - Instalar dependências Python (a partir do arquivo `requirements.txt`)
    - Instalar dependências Node.js para ferramentas de qualidade
    - Configurar diretórios de log e backup com permissões adequadas
    - Configurar serviço systemd otimizado para produção

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -57,19 +57,19 @@ project_root_path = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(project_root_path))
 print(f"!!! env.py: Added to sys.path: {str(project_root_path)} !!!")
 try:
-    from app import app, db  # Import app and db from your Flask app
+    from application import app, db  # Import app and db from your Flask app
 
-    print("!!! env.py: Successfully imported 'app' and 'db' from 'app.py' !!!")
+    print("!!! env.py: Successfully imported 'app' and 'db' from 'application.py' !!!")
     target_metadata = db.metadata
     print("!!! env.py: target_metadata set from db.metadata !!!")
 except ImportError as e:
-    print(f"!!! env.py: FAILED to import 'app' or 'db' from 'app.py': {e} !!!")
+    print(f"!!! env.py: FAILED to import 'app' or 'db' from 'application.py': {e} !!!")
     print(
-        "!!! env.py: Ensure your Flask app ('app.py') and its SQLAlchemy instance ('db') are correctly defined and accessible."
+        "!!! env.py: Ensure your Flask app ('application.py') and its SQLAlchemy instance ('db') are correctly defined and accessible."
     )
     target_metadata = None  # Keep this for safety
     raise ImportError(
-        "Could not import 'app' or 'db' from app.py, Alembic cannot proceed."
+        "Could not import 'app' or 'db' from application.py, Alembic cannot proceed."
     ) from e
 # --- End Flask-SQLAlchemy setup ---
 
@@ -97,13 +97,13 @@ def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
 
     with app.app_context():
-        # 'db' is the instance imported from app.py, which should be configured by the Flask app.
-        # The Flask app itself (app.py) handles loading .env and setting up its database URI.
+        # 'db' is the instance imported from application.py, which should be configured by the Flask app.
+        # The Flask app itself (application.py) handles loading .env and setting up its database URI.
         # db.engine should reflect that configuration.
         connectable = db.engine
         print(f"!!! env.py ONLINE: Using db.engine from Flask app: {connectable} !!!")
-        # We expect app.py to have correctly configured the DB_URI, including any SSL requirements if necessary.
-        # For example, if app.py sets SQLALCHEMY_DATABASE_URI to '...?...sslmode=require', db.engine will use it.
+        # We expect application.py to have correctly configured the DB_URI, including any SSL requirements if necessary.
+        # For example, if application.py sets SQLALCHEMY_DATABASE_URI to '...?...sslmode=require', db.engine will use it.
 
         try:
             with connectable.connect() as connection:

--- a/app.py
+++ b/app.py
@@ -1,1 +1,0 @@
-/var/www/estevaoalmeida.com.br/form-google/application.py

--- a/app/services/document_service.py
+++ b/app/services/document_service.py
@@ -280,5 +280,9 @@ class DocumentService:
 
     def __del__(self):
         """Cleanup do executor"""
+        self.close()
+
+    def close(self):
+        """Encerra explicitamente o executor de threads."""
         if hasattr(self, "_executor"):
             self._executor.shutdown(wait=True)

--- a/config.py
+++ b/config.py
@@ -4,71 +4,39 @@ import os
 
 from dotenv import load_dotenv
 
-# --- INÍCIO DA DEPURAÇÃO ADICIONAL ---
-print("=" * 50)
-print("[CONFIG_DEBUG_ENV] INICIANDO config.py")
-print("[CONFIG_DEBUG_ENV] CONTEÚDO COMPLETO DE os.environ:")
-for key, value in os.environ.items():
-    print(f"[CONFIG_DEBUG_ENV]   {key} = {value}")
-print("=" * 50)
-# --- FIM DA DEPURAÇÃO ADICIONAL ---
-
 load_dotenv(override=True)
 
 logger = logging.getLogger(__name__)
 
 # Carregar credenciais do Google como string JSON
-print("[CONFIG_DEBUG_CRED] Tentando obter GOOGLE_SERVICE_ACCOUNT_JSON do env...")
 GOOGLE_SERVICE_ACCOUNT_JSON_PATH = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")
-print(
-    f"[CONFIG_DEBUG_CRED] GOOGLE_SERVICE_ACCOUNT_JSON_PATH: {GOOGLE_SERVICE_ACCOUNT_JSON_PATH}"
-)
 GOOGLE_CREDENTIALS_AS_JSON_STR = None
-print(
-    f"[CONFIG_DEBUG_CRED] Verificando existência de: {GOOGLE_SERVICE_ACCOUNT_JSON_PATH}"
-)
 path_exists = (
     os.path.exists(GOOGLE_SERVICE_ACCOUNT_JSON_PATH)
     if GOOGLE_SERVICE_ACCOUNT_JSON_PATH
     else False
 )
-print(f"[CONFIG_DEBUG_CRED] Caminho existe? {path_exists}")
 if GOOGLE_SERVICE_ACCOUNT_JSON_PATH and path_exists:
     try:
-        print(
-            f"[CONFIG_DEBUG_CRED] Tentando abrir e carregar JSON de: {GOOGLE_SERVICE_ACCOUNT_JSON_PATH}"
-        )
         with open(GOOGLE_SERVICE_ACCOUNT_JSON_PATH, "r") as f:
             # Carrega o JSON do arquivo e o converte de volta para uma string JSON compacta
             # Isso garante que temos uma string JSON válida e não um objeto Python dict
             loaded_json = json.load(f)
-            print("[CONFIG_DEBUG_CRED] JSON carregado do arquivo com sucesso.")
             GOOGLE_CREDENTIALS_AS_JSON_STR = json.dumps(loaded_json)
-            print("[CONFIG_DEBUG_CRED] JSON convertido para string com sucesso.")
         logger.info(
             f"Credenciais Google carregadas com sucesso de {GOOGLE_SERVICE_ACCOUNT_JSON_PATH}"
         )
-        print(
-            f"[CONFIG_DEBUG_CRED] Credenciais Google carregadas com sucesso de {GOOGLE_SERVICE_ACCOUNT_JSON_PATH}"
-        )
     except Exception as e:
-        print(f"[CONFIG_DEBUG_CRED] EXCEÇÃO ao carregar credenciais: {e}")
         logger.error(
             f"Erro ao carregar ou processar o arquivo de credenciais JSON do Google ({GOOGLE_SERVICE_ACCOUNT_JSON_PATH}): {e}",
             exc_info=True,
         )
         # GOOGLE_CREDENTIALS_AS_JSON_STR permanecerá None, o que deve ser tratado na aplicação
 elif GOOGLE_SERVICE_ACCOUNT_JSON_PATH:
-    print(
-        f"[CONFIG_DEBUG_CRED] Arquivo especificado ({GOOGLE_SERVICE_ACCOUNT_JSON_PATH}) não encontrado, mas a variável de ambiente existe."
-    )
     logger.warning(
         f"Arquivo de credenciais JSON do Google especificado ({GOOGLE_SERVICE_ACCOUNT_JSON_PATH}) não encontrado."
     )
 else:
-    print(
-        "[CONFIG_DEBUG_CRED] Variável de ambiente GOOGLE_SERVICE_ACCOUNT_JSON não definida OU caminho é None."
-    )
     logger.warning("Variável de ambiente GOOGLE_SERVICE_ACCOUNT_JSON não definida.")
 
 # Configurações principais do sistema
@@ -213,10 +181,3 @@ config_by_name = {
     "testing": TestingConfig,
     "default": DevelopmentConfig,
 }
-
-print(
-    f"[CONFIG_DEBUG_FINAL] Valor final de GOOGLE_CREDENTIALS_AS_JSON_STR APÓS definição do CONFIG: {CONFIG.get('GOOGLE_CREDENTIALS_AS_JSON_STR') is not None}"
-)
-print("=" * 50)
-print("[CONFIG_DEBUG_ENV] FINALIZANDO config.py")
-print("=" * 50)

--- a/form_google_celery.service
+++ b/form_google_celery.service
@@ -17,7 +17,7 @@ Environment="PATH=/var/www/estevaoalmeida.com.br/form-google/venv/bin"
 # Variáveis de ambiente do projeto
 EnvironmentFile=/var/www/estevaoalmeida.com.br/form-google/.env
 # Garante que Flask leia config correta (opcional)
-Environment="FLASK_APP=app.py"
+Environment="FLASK_APP=application.py"
 Environment="FLASK_ENV=production"
 Environment="PYTHONPATH=/var/www/estevaoalmeida.com.br/form-google"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+Flask
+Flask-SQLAlchemy
+Flask-Migrate
+Flask-Limiter
+Flask-Talisman
+Flask-WTF
+gunicorn
+celery
+requests
+psycopg2-binary
+python-dotenv
+google-api-python-client
+oauth2client
+pytest

--- a/security_middleware.py
+++ b/security_middleware.py
@@ -4,6 +4,7 @@ Middleware de segurança para a aplicação Flask.
 
 import time
 from functools import wraps
+import os
 
 from flask import g, jsonify, request
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -5,7 +5,7 @@ logging.basicConfig(level=logging.DEBUG)
 logging.debug("WSGI.PY: Inicializando aplicação")
 
 # Importa a instância da aplicação já configurada
-from app import app
+from application import app
 
 if __name__ == "__main__":
     # Este bloco é para executar o servidor de desenvolvimento do Flask.


### PR DESCRIPTION
## Summary
- clean debugging prints from config
- import `os` in security middleware
- point wsgi to `application` module
- allow Celery service to load `application.py`
- add explicit `close()` method to `DocumentService`
- provide `requirements.txt`
- update Alembic env to reference `application.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for psycopg2, dotenv, requests)*

------
https://chatgpt.com/codex/tasks/task_e_685991c32c708322921e05769b60a3d9