### PR TITLE
Add os import

### DIFF
--- a/security_middleware.py
+++ b/security_middleware.py
@@ -4,6 +4,7 @@ Middleware de segurança para a aplicação Flask.
 
 import time
 from functools import wraps
+import os
 
 from flask import g, jsonify, request
 


### PR DESCRIPTION
## Summary
- add missing `os` import in `security_middleware.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_685992f4c31c83228df80e3898b03e40