### PR TITLE
Add requirements file and mention in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ ENV/
 #########################
 # pip-tools
 requirements*.txt
+!requirements.txt
 # Poetry
 poetry.lock
 # conda

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ O backup é configurado automaticamente durante a instalação. Os arquivos prin
   sudo apt update && sudo apt install -y git python3-venv python3-pip python3-dev build-essential libssl-dev libffi-dev python3-setuptools rclone nodejs npm
   ```
 - **OpenSSL** para geração de certificados (já incluído na maioria das distribuições)
+- As dependências Python (execução e testes) estão listadas em `requirements.txt`.
 
 ---
 
@@ -282,7 +283,7 @@ O script `install.sh` automatiza a configuração do ambiente e instalação da 
 
    - Instalar dependências do sistema (python3-venv, nginx, rclone, nodejs, etc.)
    - Criar e configurar ambiente virtual Python (`venv`)
-   - Instalar dependências Python de segurança (do arquivo `requirements-secure.txt`)
+   - instalar dependências Python (do arquivo `requirements.txt`)
    - Instalar dependências Node.js para ferramentas de qualidade
    - Configurar diretórios de log e backup com permissões adequadas
    - Configurar serviço systemd otimizado para produção

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,25 @@
+Flask
+Flask-Limiter
+Flask-Login
+Flask-WTF
+Flask-Talisman
+Flask-Migrate
+Flask-SQLAlchemy
+SQLAlchemy
+celery
+python-dotenv
+requests
+psycopg2-binary
+gunicorn
+google-api-python-client
+oauth2client
+python-dateutil
+# Test dependencies
+pytest
+pytest-cov
+black
+isort
+flake8
+mypy
+types-requests
+types-python-dateutil


### PR DESCRIPTION
## Summary
- add `requirements.txt` with runtime and test packages
- reference the new file in setup instructions
- allow tracking requirements.txt in git

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: psycopg2)*

------
https://chatgpt.com/codex/tasks/task_e_6859931899a883229cabdc39e7bed499