### PR TITLE
Add explicit close method for DocumentService

### DIFF
--- a/MELHORIAS_IMPLEMENTADAS.md
+++ b/MELHORIAS_IMPLEMENTADAS.md
@@ -43,6 +43,7 @@ MELHORIAS_IMPLEMENTADAS.md    # Este arquivo
 # Exemplo de uso
 document_service = DocumentService(CONFIG)
 sucessos, erros = document_service.gerar_documentos_cliente(cliente_data)
+document_service.close()
 ```
 
 ### 2. **Validação Robusta de Dados** (`app/validators/cliente_validator.py`)
@@ -222,6 +223,7 @@ except ValueError as e:
 # 2. Gerar documentos
 document_service = DocumentService(CONFIG)
 sucessos, erros = document_service.gerar_documentos_cliente(cliente_data)
+document_service.close()
 
 # 3. Retornar resultado
 if erros and not sucessos:

--- a/app/api/document_api.py
+++ b/app/api/document_api.py
@@ -120,8 +120,8 @@ def gerar_documento_api_refatorada():
             return _create_error_response(str(e), 400, request_id)
 
         # 4. Processar geração de documentos
+        document_service = DocumentService(CONFIG)
         try:
-            document_service = DocumentService(CONFIG)
             sucessos, erros = document_service.gerar_documentos_cliente(cliente_data)
         except Exception as e:
             logger.error(
@@ -136,6 +136,8 @@ def gerar_documento_api_refatorada():
             return _create_error_response(
                 "Erro interno no processamento de documentos", 500, request_id
             )
+        finally:
+            document_service.close()
 
         # 5. Preparar resposta
         duration = time.time() - start_time

--- a/app/services/document_service.py
+++ b/app/services/document_service.py
@@ -54,7 +54,11 @@ class ClienteData:
 
 
 class DocumentService:
-    """Service para gerar documentos com melhorias de performance e tratamento de erros"""
+    """Service para gerar documentos com melhorias de performance e tratamento de erros.
+
+    Chame :py:meth:`close` quando o serviço não for mais necessário para liberar
+    recursos do ``ThreadPoolExecutor``.
+    """
 
     def __init__(self, config: Dict):
         self.config = config
@@ -278,7 +282,12 @@ class DocumentService:
 
         return endereco
 
+    def close(self) -> None:
+        """Encerra o executador de tarefas paralelas."""
+        if getattr(self, "_executor", None):
+            self._executor.shutdown(wait=True)
+            self._executor = None
+
     def __del__(self):
         """Cleanup do executor"""
-        if hasattr(self, "_executor"):
-            self._executor.shutdown(wait=True)
+        self.close()


### PR DESCRIPTION
## Summary
- add `close` method in `DocumentService` and update `__del__`
- call `document_service.close()` after document creation
- document closure requirement in examples

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for psycopg2, requests and dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_6859931ebfa483229046b6ce6ab44e49