### PR TITLE
Fix API key middleware import

### DIFF
--- a/security_middleware.py
+++ b/security_middleware.py
@@ -6,6 +6,7 @@ import time
 from functools import wraps
 
 from flask import g, jsonify, request
+import os
 
 
 class SecurityMiddleware:


### PR DESCRIPTION
## Summary
- import `os` to allow API key lookup via `os.getenv`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6859a802500c8322894d468d3f62cf4d