### PR TITLE
Replace print debugging with logging

### DIFF
--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -117,6 +117,8 @@ def setup_logging(app, log_level: str = "INFO"):
         "app.validators.cliente_validator",
         "app.api.document_api",
         "document_generator",
+        "app.tasks.document_generation",
+        "config",
     ]
 
     for logger_name in loggers_to_configure:

--- a/app/tasks/document_generation.py
+++ b/app/tasks/document_generation.py
@@ -123,16 +123,11 @@ def gerar_documentos_task(
     logger.info(f"Iniciando gerar_documentos_task para resposta_id: {resposta_id}")
 
     # Debug: Log dos dados recebidos
-    with open(
-        "/var/www/estevaoalmeida.com.br/form-google/debug_celery_task.log", "a"
-    ) as f:
-        f.write(f"[CELERY_DEBUG] resposta_id: {resposta_id}\n")
-        f.write(f"[CELERY_DEBUG] tipo_pessoa: {tipo_pessoa}\n")
-        f.write(
-            f"[CELERY_DEBUG] dados_cliente_json (tipo): {type(dados_cliente_json)}\n"
-        )
-        f.write(f"[CELERY_DEBUG] dados_cliente_json (conteúdo): {dados_cliente_json}\n")
-        f.write(f"[CELERY_DEBUG] documentos_requeridos: {documentos_requeridos}\n")
+    logger.debug("[CELERY_DEBUG] resposta_id: %s", resposta_id)
+    logger.debug("[CELERY_DEBUG] tipo_pessoa: %s", tipo_pessoa)
+    logger.debug("[CELERY_DEBUG] dados_cliente_json (tipo): %s", type(dados_cliente_json))
+    logger.debug("[CELERY_DEBUG] dados_cliente_json (conteúdo): %s", dados_cliente_json)
+    logger.debug("[CELERY_DEBUG] documentos_requeridos: %s", documentos_requeridos)
 
     resposta = RespostaForm.query.get(resposta_id)
     if not resposta:
@@ -155,22 +150,12 @@ def gerar_documentos_task(
         # Debug: Verificar se dados_cliente_json é string ou dict
         if isinstance(dados_cliente_json, str):
             dados_cliente = json.loads(dados_cliente_json)
-            with open(
-                "/var/www/estevaoalmeida.com.br/form-google/debug_celery_task.log", "a"
-            ) as f:
-                f.write(
-                    f"[CELERY_DEBUG] dados_cliente_json era string, convertido para dict\n"
-                )
-                f.write(
-                    f"[CELERY_DEBUG] dados_cliente (após conversão): {dados_cliente}\n"
-                )
+            logger.debug("[CELERY_DEBUG] dados_cliente_json era string, convertido para dict")
+            logger.debug("[CELERY_DEBUG] dados_cliente (após conversão): %s", dados_cliente)
         else:
             dados_cliente = dados_cliente_json
-            with open(
-                "/var/www/estevaoalmeida.com.br/form-google/debug_celery_task.log", "a"
-            ) as f:
-                f.write(f"[CELERY_DEBUG] dados_cliente_json já era dict\n")
-                f.write(f"[CELERY_DEBUG] dados_cliente: {dados_cliente}\n")
+            logger.debug("[CELERY_DEBUG] dados_cliente_json já era dict")
+            logger.debug("[CELERY_DEBUG] dados_cliente: %s", dados_cliente)
 
         current_app.logger.info(
             "Chamando service.generate_documents para tipo_pessoa='%s' com documentos: %s",

--- a/config.py
+++ b/config.py
@@ -4,69 +4,74 @@ import os
 
 from dotenv import load_dotenv
 
-# --- INÍCIO DA DEPURAÇÃO ADICIONAL ---
-print("=" * 50)
-print("[CONFIG_DEBUG_ENV] INICIANDO config.py")
-print("[CONFIG_DEBUG_ENV] CONTEÚDO COMPLETO DE os.environ:")
-for key, value in os.environ.items():
-    print(f"[CONFIG_DEBUG_ENV]   {key} = {value}")
-print("=" * 50)
-# --- FIM DA DEPURAÇÃO ADICIONAL ---
-
 load_dotenv(override=True)
 
 logger = logging.getLogger(__name__)
 
+# Permite logs de depuração extensos apenas quando DEBUG_CONFIG=1
+DEBUG_CONFIG = os.getenv("DEBUG_CONFIG") == "1"
+
+if DEBUG_CONFIG:
+    logger.debug("=" * 50)
+    logger.debug("[CONFIG_DEBUG_ENV] INICIANDO config.py")
+    logger.debug("[CONFIG_DEBUG_ENV] CONTEÚDO COMPLETO DE os.environ:")
+    for key, value in os.environ.items():
+        logger.debug("[CONFIG_DEBUG_ENV]   %s = %s", key, value)
+    logger.debug("=" * 50)
+
 # Carregar credenciais do Google como string JSON
-print("[CONFIG_DEBUG_CRED] Tentando obter GOOGLE_SERVICE_ACCOUNT_JSON do env...")
+logger.debug(
+    "[CONFIG_DEBUG_CRED] Tentando obter GOOGLE_SERVICE_ACCOUNT_JSON do env..."
+)
 GOOGLE_SERVICE_ACCOUNT_JSON_PATH = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")
-print(
-    f"[CONFIG_DEBUG_CRED] GOOGLE_SERVICE_ACCOUNT_JSON_PATH: {GOOGLE_SERVICE_ACCOUNT_JSON_PATH}"
+logger.debug(
+    "[CONFIG_DEBUG_CRED] GOOGLE_SERVICE_ACCOUNT_JSON_PATH: %s",
+    GOOGLE_SERVICE_ACCOUNT_JSON_PATH,
 )
 GOOGLE_CREDENTIALS_AS_JSON_STR = None
-print(
-    f"[CONFIG_DEBUG_CRED] Verificando existência de: {GOOGLE_SERVICE_ACCOUNT_JSON_PATH}"
+logger.debug(
+    "[CONFIG_DEBUG_CRED] Verificando existência de: %s",
+    GOOGLE_SERVICE_ACCOUNT_JSON_PATH,
 )
 path_exists = (
     os.path.exists(GOOGLE_SERVICE_ACCOUNT_JSON_PATH)
     if GOOGLE_SERVICE_ACCOUNT_JSON_PATH
     else False
 )
-print(f"[CONFIG_DEBUG_CRED] Caminho existe? {path_exists}")
+logger.debug("[CONFIG_DEBUG_CRED] Caminho existe? %s", path_exists)
 if GOOGLE_SERVICE_ACCOUNT_JSON_PATH and path_exists:
     try:
-        print(
-            f"[CONFIG_DEBUG_CRED] Tentando abrir e carregar JSON de: {GOOGLE_SERVICE_ACCOUNT_JSON_PATH}"
+        logger.debug(
+            "[CONFIG_DEBUG_CRED] Tentando abrir e carregar JSON de: %s",
+            GOOGLE_SERVICE_ACCOUNT_JSON_PATH,
         )
         with open(GOOGLE_SERVICE_ACCOUNT_JSON_PATH, "r") as f:
             # Carrega o JSON do arquivo e o converte de volta para uma string JSON compacta
             # Isso garante que temos uma string JSON válida e não um objeto Python dict
             loaded_json = json.load(f)
-            print("[CONFIG_DEBUG_CRED] JSON carregado do arquivo com sucesso.")
+            logger.debug("[CONFIG_DEBUG_CRED] JSON carregado do arquivo com sucesso.")
             GOOGLE_CREDENTIALS_AS_JSON_STR = json.dumps(loaded_json)
-            print("[CONFIG_DEBUG_CRED] JSON convertido para string com sucesso.")
+            logger.debug("[CONFIG_DEBUG_CRED] JSON convertido para string com sucesso.")
         logger.info(
             f"Credenciais Google carregadas com sucesso de {GOOGLE_SERVICE_ACCOUNT_JSON_PATH}"
         )
-        print(
-            f"[CONFIG_DEBUG_CRED] Credenciais Google carregadas com sucesso de {GOOGLE_SERVICE_ACCOUNT_JSON_PATH}"
-        )
     except Exception as e:
-        print(f"[CONFIG_DEBUG_CRED] EXCEÇÃO ao carregar credenciais: {e}")
         logger.error(
             f"Erro ao carregar ou processar o arquivo de credenciais JSON do Google ({GOOGLE_SERVICE_ACCOUNT_JSON_PATH}): {e}",
             exc_info=True,
         )
         # GOOGLE_CREDENTIALS_AS_JSON_STR permanecerá None, o que deve ser tratado na aplicação
 elif GOOGLE_SERVICE_ACCOUNT_JSON_PATH:
-    print(
-        f"[CONFIG_DEBUG_CRED] Arquivo especificado ({GOOGLE_SERVICE_ACCOUNT_JSON_PATH}) não encontrado, mas a variável de ambiente existe."
+    logger.warning(
+        "[CONFIG_DEBUG_CRED] Arquivo especificado (%s) não encontrado, mas a variável de ambiente existe.",
+        GOOGLE_SERVICE_ACCOUNT_JSON_PATH,
     )
     logger.warning(
-        f"Arquivo de credenciais JSON do Google especificado ({GOOGLE_SERVICE_ACCOUNT_JSON_PATH}) não encontrado."
+        "Arquivo de credenciais JSON do Google especificado (%s) não encontrado.",
+        GOOGLE_SERVICE_ACCOUNT_JSON_PATH,
     )
 else:
-    print(
+    logger.warning(
         "[CONFIG_DEBUG_CRED] Variável de ambiente GOOGLE_SERVICE_ACCOUNT_JSON não definida OU caminho é None."
     )
     logger.warning("Variável de ambiente GOOGLE_SERVICE_ACCOUNT_JSON não definida.")
@@ -214,9 +219,10 @@ config_by_name = {
     "default": DevelopmentConfig,
 }
 
-print(
-    f"[CONFIG_DEBUG_FINAL] Valor final de GOOGLE_CREDENTIALS_AS_JSON_STR APÓS definição do CONFIG: {CONFIG.get('GOOGLE_CREDENTIALS_AS_JSON_STR') is not None}"
+logger.debug(
+    "[CONFIG_DEBUG_FINAL] Valor final de GOOGLE_CREDENTIALS_AS_JSON_STR APÓS definição do CONFIG: %s",
+    CONFIG.get("GOOGLE_CREDENTIALS_AS_JSON_STR") is not None,
 )
-print("=" * 50)
-print("[CONFIG_DEBUG_ENV] FINALIZANDO config.py")
-print("=" * 50)
+logger.debug("=" * 50)
+logger.debug("[CONFIG_DEBUG_ENV] FINALIZANDO config.py")
+logger.debug("=" * 50)

--- a/wsgi.py
+++ b/wsgi.py
@@ -21,7 +21,10 @@ if __name__ == "__main__":
         os.environ.get("FLASK_DEBUG", "1") == "1"
     )  # '1' para True, '0' para False
 
-    print(
-        f"Iniciando servidor de desenvolvimento em http://{host}:{port}/ (Debug: {debug_mode})"
+    logging.info(
+        "Iniciando servidor de desenvolvimento em http://%s:%s/ (Debug: %s)",
+        host,
+        port,
+        debug_mode,
     )
     app.run(host=host, port=port, debug=debug_mode)


### PR DESCRIPTION
## Summary
- route debug messages through logger instead of `print`
- remove direct file writes in `document_generation` task
- register new loggers in `logging_config`
- log server startup from `wsgi`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6859a81f65cc8322b065408edb3ce78a