### PR TITLE
Centralize placeholder mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ O núcleo da aplicação é a capacidade de gerar documentos Google Docs automat
 ### Mapeamento de Placeholders
 
 - **Formato:** Os placeholders no seu template do Google Docs devem seguir o formato `{{Nome_Do_Placeholder}}`.
-- **Mapeamento Interno:** O sistema possui um mapa interno (`document_generator.py`) que converte os campos do formulário (ex: `primeiroNome`) para os placeholders correspondentes no template (ex: `{{Primeiro Nome}}`).
+- **Mapeamento Interno:** O mapeamento de campos agora está centralizado em `app/placeholder_mapping.py`. Ele define como cada campo de registro (ex: `primeiroNome`) corresponde ao placeholder do template (ex: `{{Primeiro Nome}}`). Utilize esse módulo ao adicionar novos campos para manter a consistência.
 - **Placeholders de Endereço:** Para endereços, utilize os placeholders detalhados para garantir o preenchimento correto: `{{Endereço_Logradouro}}`, `{{Endereço_Numero}}`, `{{Endereço_Bairro}}`, `{{Endereço_CEP}}`, `{{Endereço_Cidade}}`, `{{Endereço_Estado}}` e `{{Endereço_Complemento}}`.
 
 ### Placeholders Especiais

--- a/app/placeholder_mapping.py
+++ b/app/placeholder_mapping.py
@@ -1,0 +1,48 @@
+"""Mapping of registration fields to Google Docs template placeholders."""
+
+# Pessoa Física (PF) mapping
+PLACEHOLDER_MAPPING_PF = {
+    "primeiroNome": "Primeiro Nome",
+    "sobrenome": "Sobrenome",
+    "nacionalidade": "Nacionalidade",
+    "estadoCivil": "Estado Civil",
+    "profissao": "Profissão",
+    "dataNascimento": "Nascimento",
+    "cpf": "CPF",
+    "rg": "RG",
+    "estadoEmissorRG": "Estado emissor do RG",
+    "cnh": "CNH",
+    "cep": "Endereço_CEP",
+    "logradouro": "Endereço_Logradouro",
+    "numero": "Endereço_Numero",
+    "complemento": "Endereço_Complemento",
+    "bairro": "Endereço_Bairro",
+    "cidade": "Endereço_Cidade",
+    "estado": "Endereço_Estado",
+    "email": "E-mail",
+    "telefoneCelular": "Telefone Celular",
+    "outroTelefone": "Outro telefone",
+}
+
+# Pessoa Jurídica (PJ) mapping
+PLACEHOLDER_MAPPING_PJ = {
+    "razaoSocial": "Razão Social",
+    "nomeFantasia": "Nome Fantasia",
+    "cnpj": "CNPJ",
+    "inscricaoEstadual": "Inscrição Estadual",
+    "dataFundacao": "Data de Fundação",
+    "cep": "Endereço_CEP",
+    "logradouro": "Endereço_Logradouro",
+    "numero": "Endereço_Numero",
+    "complemento": "Endereço_Complemento",
+    "bairro": "Endereço_Bairro",
+    "cidade": "Endereço_Cidade",
+    "estado": "Endereço_Estado",
+    "email": "E-mail",
+    "telefoneCelular": "Telefone Celular",
+    "outroTelefone": "Outro telefone",
+    "nomeCompletoContato": "Nome Contato PJ",
+    "emailContato": "E-mail Contato PJ",
+    "telefoneContato": "Telefone Contato PJ",
+    "cargoContato": "Cargo Contato PJ",
+}

--- a/document_generator.py
+++ b/document_generator.py
@@ -9,55 +9,15 @@ from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
+from app.placeholder_mapping import (
+    PLACEHOLDER_MAPPING_PF as MAPEAMENTO_CHAVES_TEMPLATE_PF,
+)
+from app.placeholder_mapping import (
+    PLACEHOLDER_MAPPING_PJ as MAPEAMENTO_CHAVES_TEMPLATE_PJ,
+)
 from config import CONFIG
 
 logger = logging.getLogger(__name__)
-
-MAPEAMENTO_CHAVES_TEMPLATE_PF = {
-    "primeiroNome": "Primeiro Nome",
-    "sobrenome": "Sobrenome",
-    "nacionalidade": "Nacionalidade",
-    "estadoCivil": "Estado Civil",
-    "profissao": "Profissão",
-    "dataNascimento": "Nascimento",
-    "cpf": "CPF",
-    "rg": "RG",
-    "estadoEmissorRG": "Estado emissor do RG",
-    "cnh": "CNH",
-    "cep": "Endereço_CEP",
-    "logradouro": "Endereço_Logradouro",
-    "numero": "Endereço_Numero",
-    "complemento": "Endereço_Complemento",
-    "bairro": "Endereço_Bairro",
-    "cidade": "Endereço_Cidade",
-    "estado": "Endereço_Estado",
-    "email": "E-mail",
-    "telefoneCelular": "Telefone Celular",
-    "outroTelefone": "Outro telefone",
-}
-
-MAPEAMENTO_CHAVES_TEMPLATE_PJ = {
-    "razaoSocial": "Razão Social",
-    "nomeFantasia": "Nome Fantasia",
-    "cnpj": "CNPJ",
-    "inscricaoEstadual": "Inscrição Estadual",
-    "dataFundacao": "Data de Fundação",
-    "cep": "Endereço_CEP",
-    "logradouro": "Endereço_Logradouro",
-    "numero": "Endereço_Numero",
-    "complemento": "Endereço_Complemento",
-    "bairro": "Endereço_Bairro",
-    "cidade": "Endereço_Cidade",
-    "estado": "Endereço_Estado",
-    "email": "E-mail",  # Email principal da PJ
-    "telefoneCelular": "Telefone Celular",  # Telefone principal da PJ (pode ser fixo ou móvel)
-    "outroTelefone": "Outro telefone",
-    # Campos de contato para PJ (ajuste os placeholders conforme seu template)
-    "nomeCompletoContato": "Nome Contato PJ",  # Ex: se o payload enviar 'nomeCompletoContato'
-    "emailContato": "E-mail Contato PJ",
-    "telefoneContato": "Telefone Contato PJ",
-    "cargoContato": "Cargo Contato PJ",
-}
 # Configurar o logger se ainda não estiver configurado no app principal
 if not logger.hasHandlers():
     logging.basicConfig(


### PR DESCRIPTION
## Summary
- centralize field/placeholder definitions in `app/placeholder_mapping.py`
- reuse the mapping in the Google Docs generator
- use mapping in API form handler and document service
- document the mapping in README

## Testing
- `pre-commit run --files app/placeholder_mapping.py document_generator.py app/services/document_service.py app/api/document_api.py README.md` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*
- `black --check app/placeholder_mapping.py document_generator.py app/services/document_service.py app/api/document_api.py`
- `isort --check-only app/placeholder_mapping.py document_generator.py app/services/document_service.py app/api/document_api.py`
- `flake8 app/placeholder_mapping.py document_generator.py app/services/document_service.py app/api/document_api.py` *(fails: command not found)*
- `mypy app/placeholder_mapping.py document_generator.py app/services/document_service.py app/api/document_api.py` *(fails: Error importing plugin 'pydantic.mypy')*

------
https://chatgpt.com/codex/tasks/task_e_68599ead3e208322b663c97a8d1c2607