### PR TITLE
Add pinned requirements file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ ENV/
 #########################
 # pip-tools
 requirements*.txt
+!requirements.txt
 # Poetry
 poetry.lock
 # conda

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+black==25.1.0
+click==8.2.1
+iniconfig==2.1.0
+isort==6.0.1
+mypy==1.16.1
+mypy_extensions==1.1.0
+nodeenv==1.9.1
+packaging==25.0
+pathspec==0.12.1
+platformdirs==4.3.8
+pluggy==1.6.0
+Pygments==2.19.1
+pyright==1.1.402
+pytest==8.4.0
+ruff==0.11.13
+typing_extensions==4.14.0


### PR DESCRIPTION
## Summary
- add `requirements.txt` with pinned versions from `pip freeze`
- allow tracking of `requirements.txt` in `.gitignore`

## Testing
- `pip freeze`

------
https://chatgpt.com/codex/tasks/task_e_68599e9f508c8322bd25b63ff62359ae