### PR TITLE
Add environment example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+# Example configuration for form-google
+
+# Database configuration
+DB_USER=postgres
+DB_PASS=postgres
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=form_google
+
+# Service account credentials for Google APIs
+# Path to the JSON file used to authenticate API requests
+GOOGLE_SERVICE_ACCOUNT_JSON=/path/to/credentials.json
+
+# IDs used by the application
+SPREADSHEET_ID=""         # ID da planilha principal no Google Sheets
+PARENT_FOLDER_ID=""        # Pasta raiz onde serão criadas subpastas de clientes
+BACKUP_FOLDER_ID=""        # Pasta do Google Drive para armazenar backups
+
+# Email administrativo para relatórios
+ADMIN_EMAIL=""
+
+# IDs dos templates do Google Docs
+TEMPLATE_PF_FICHA_CADASTRAL=""
+TEMPLATE_PF_CONTRATO_HONORARIOS=""
+TEMPLATE_PF_PROCURACAO_JUDICIAL=""
+TEMPLATE_PF_PROCURACAO_ADMINISTRATIVA=""
+TEMPLATE_PF_CONTRATO_ADMINISTRATIVO=""
+TEMPLATE_PF_DECLARACAO_POBREZA=""
+TEMPLATE_PJ_FICHA_CADASTRAL=""
+TEMPLATE_PJ_CONTRATO_HONORARIOS=""
+TEMPLATE_PJ_PROCURACAO_JUDICIAL=""
+TEMPLATE_PJ_PROCURACAO_ADMINISTRATIVA=""
+TEMPLATE_PET_SUSPENSAO_DIREITO_DIRIGIR=""
+
+# Opcional: chaves de API internas
+INTERNAL_API_KEY=""
+SECRET_KEY=""
+
+# Backup and log scheduling (cron syntax)
+# Backup diário às 02:00
+BACKUP_SCHEDULE="0 2 * * *"
+# Sincronização com Google Drive logo após o backup
+SYNC_GDRIVE_SCHEDULE="5 2 * * *"
+# Limpeza de logs às 01:00
+LOG_CLEANUP_SCHEDULE="0 1 * * *"

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ O script `install.sh` automatiza a configuração do ambiente e instalação da 
 
 4. **Pós-instalação:**
    - O script criará um arquivo `.env` de exemplo
+   - Edite esse arquivo conforme necessário. Ele contém variáveis como `GOOGLE_SERVICE_ACCOUNT_JSON` e `BACKUP_FOLDER_ID` e define os horários de backup (`BACKUP_SCHEDULE`, `SYNC_GDRIVE_SCHEDULE`, `LOG_CLEANUP_SCHEDULE`).
    - Serão configuradas permissões de arquivos e diretórios
    - Serão habilitados e iniciados os serviços necessários
    - O primeiro backup será executado automaticamente


### PR DESCRIPTION
## Summary
- add `.env.example` with Google credentials and backup schedule variables
- mention editing `.env` after install in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: psycopg2)*

------
https://chatgpt.com/codex/tasks/task_e_6859ab7771a08322b53b87182de403df