### PR TITLE
Update install process to use setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Se precisar reconfigurar o acesso ao Google Drive:
 
    ```bash
    source venv/bin/activate
-   pip install -r requirements.txt
+   pip install .
    npm install  # Para ferramentas de qualidade de código
    ```
 

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,13 @@ source .venv/bin/activate
 
 # 3. Instalar dependências Python
 pip install --upgrade pip
-pip install -r requirements.txt
+if [ -f requirements.txt ]; then
+  pip install -r requirements.txt
+elif [ -f pyproject.toml ] || [ -f setup.py ]; then
+  pip install .
+else
+  echo "[WARN] Nenhum arquivo requirements.txt ou pyproject.toml/setup.py encontrado."
+fi
 
 # 4. Instalar dependências extras de desenvolvimento (opcional)
 if [ -f requirements-dev.txt ]; then


### PR DESCRIPTION
## Summary
- update `install.sh` to fallback on `setup.py`/`pyproject.toml` when `requirements.txt` is missing
- update README to document new installation command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_6859acd827408322bb0ef8b9b4782b0a