### PR TITLE
Update peticionador routes logging

### DIFF
--- a/app/peticionador/routes.py
+++ b/app/peticionador/routes.py
@@ -22,6 +22,7 @@ from wtforms.validators import DataRequired
 
 from app.peticionador import google_services
 from app.peticionador.utils import get_enum_display_name
+from config import CONFIG
 
 # Ajuste o import de 'db' conforme a estrutura do seu projeto.
 # from app import db
@@ -1177,7 +1178,9 @@ def gerar_documento_suspensao(cliente_id):
                         "ID do template de suspensão não encontrado nas configurações."
                     )
             except KeyError as e:
-                logger.error(f"Erro ao obter ID do template de suspensão: {e}")
+                current_app.logger.error(
+                    f"Erro ao obter ID do template de suspensão: {e}"
+                )
                 flash(
                     "Erro de configuração: ID do template de suspensão não definido. Contate o administrador.",
                     "danger",


### PR DESCRIPTION
## Summary
- import CONFIG from `config.py`
- use `current_app.logger` when reporting template ID error

## Testing
- `black app/peticionador/routes.py --check`
- `isort app/peticionador/routes.py --check --profile black`
- `mypy app/peticionador/routes.py` *(fails: Error importing plugin "pydantic.mypy")*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2', 'dotenv', 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6859af929a208322bd36b349b5861507