### PR TITLE
Restrict dev admin setup route

### DIFF
--- a/app/peticionador/routes.py
+++ b/app/peticionador/routes.py
@@ -477,10 +477,16 @@ def logout():
     return redirect(url_for("peticionador.login"))
 
 
-# Rota para criar um usuário de teste (APENAS PARA DESENVOLVIMENTO)
-# Remova ou proteja adequadamente em produção.
+# Rota exclusiva para desenvolvimento. Avalie removê-la em produção.
+# Caso seja mantida, o acesso é restrito a usuários autenticados e
+# bloqueado em ambiente de produção.
 @peticionador_bp.route("/setup_admin_dev")
+@login_required
 def setup_admin_dev():
+    """Cria usuário admin para testes. Não habilitar em produção."""
+    if current_app.config.get("ENV") == "production":
+        abort(404)
+
     email_admin = "fabricionext@gmail.com"
     # Verifica se o usuário admin já existe
     admin_user = User.query.filter_by(email=email_admin).first()


### PR DESCRIPTION
## Summary
- block `/setup_admin_dev` in production and require login
- add docstring explaining the route is for dev use only

## Testing
- `black --check app/peticionador/routes.py`
- `isort --check --profile black app/peticionador/routes.py`
- `flake8 app/peticionador/routes.py` *(fails: command not found)*
- `mypy app/peticionador/routes.py` *(fails: No module named 'pydantic')*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6859afdc83288322954a704d0634a9cc